### PR TITLE
adds python scripts that populate and delete local MySQL DB

### DIFF
--- a/addCustomers.py
+++ b/addCustomers.py
@@ -1,0 +1,91 @@
+import pymysql
+import names
+import random
+import string
+
+# Connection Config Values
+rds_endpoint='localhost'
+username='root'
+password='<Put MySQL Server Password Here>'
+database_name = 'testudo_bank'
+
+# SQL Config Values
+num_customers_to_add = 100
+
+# Connect to testudo_bank db in local MySQL Server
+connection = pymysql.connect(host=rds_endpoint, user=username, passwd = password, db=database_name)
+cursor = connection.cursor()
+
+# Make empty Customers table
+create_customer_table_sql = '''
+  CREATE TABLE Customers (
+    CustomerID varchar(255),
+    FirstName varchar(255),
+    LastName varchar(255),
+    Balance int
+  );
+  '''
+cursor.execute(create_customer_table_sql)
+
+# Make empty Passwords table
+create_password_table_sql = '''
+CREATE TABLE Passwords (
+  CustomerID varchar(255),
+  Password varchar(255)
+);
+'''
+cursor.execute(create_password_table_sql)
+
+# The two sets created below are used to ensure that this
+# automated, randomized process does not accidentally 
+# generate and use a customer ID that already is in use
+
+# Add all existing customer IDs in the DB to a set
+get_all_ids_sql = '''SELECT CustomerID FROM Customers;'''
+cursor.execute(get_all_ids_sql)
+ids_in_db = set()
+for id in cursor.fetchall():
+  ids_in_db.add(id[0])
+
+# a set to store all IDs that are added in this Lambda 
+# (so that we don't need to run a SELECT SQL query again)
+ids_just_added = set()
+
+# add random customers
+for i in range(num_customers_to_add):
+  # generate random 9-digit customer ID
+  customer_id = ''.join(random.choices(string.digits, k = 9))
+
+  # don't add row if someone already has this ID (really unlikely)
+  if (customer_id not in ids_in_db and customer_id not in ids_just_added):
+
+    # generate random name, balance, and password
+    customer_first_name = names.get_first_name()
+    customer_last_name = names.get_last_name()
+    customer_balance = random.randint(100, 10000)
+    customer_password = ''.join(random.choices(string.ascii_lowercase + string.ascii_uppercase + string.digits, k = 9))
+    
+    # add customer ID, name, and balance to Customers table
+    insert_customer_sql = '''
+    INSERT INTO Customers
+    VALUES  ({0},{1},{2},{3});
+    '''.format("'" + customer_id + "'",
+                "'" + customer_first_name + "'",
+                "'" + customer_last_name + "'",
+                customer_balance)
+    cursor.execute(insert_customer_sql)
+    
+    # add customer ID and password to Passwords table
+    insert_password_sql = '''
+    INSERT INTO Passwords
+    VALUES  ({0},{1});
+    '''.format("'" + customer_id + "'",
+                "'" + customer_password + "'")
+    cursor.execute(insert_password_sql)
+    
+    # add this customer's randomly-generated ID to the set
+    # to ensure this ID is not re-used by accident.
+    ids_just_added.add(customer_id)
+
+connection.commit()
+cursor.close()

--- a/createDB.py
+++ b/createDB.py
@@ -1,0 +1,23 @@
+import pymysql
+import names
+import random
+import string
+
+# Connection Config Values
+rds_endpoint='localhost'
+username='root'
+password='<Put MySQL Server Password Here>'
+database_name = 'testudo_bank'
+
+# Connect to local MySQL Server and create a DB called 'testudo_bank'
+connection = pymysql.connect(host=rds_endpoint, user=username, passwd = password)
+cursor = connection.cursor()
+
+create_testudo_bank_db_sql = '''
+CREATE DATABASE {};
+'''.format(database_name)
+
+cursor.execute(create_testudo_bank_db_sql)
+
+connection.commit()
+cursor.close()

--- a/teardownDB.py
+++ b/teardownDB.py
@@ -1,0 +1,23 @@
+import pymysql
+import names
+import random
+import string
+
+# Connection Config Values
+rds_endpoint='localhost'
+username='root'
+password='<Put MySQL Server Password Here>'
+database_name = 'testudo_bank'
+
+# Connect to local MySQL Server and delete a DB called 'testudo_bank'
+connection = pymysql.connect(host=rds_endpoint, user=username, passwd = password)
+cursor = connection.cursor()
+
+delete_testudo_bank_db_sql = '''
+DROP DATABASE {};
+'''.format(database_name)
+
+cursor.execute(delete_testudo_bank_db_sql)
+
+connection.commit()
+cursor.close()


### PR DESCRIPTION
Adds 3 python scripts that automate creation and deletion of the local MySQL DB used by the testudo-bank application. Intended to help students ramp up quickly with the DB without much knowledge of Python or SQL.

createDB.py simply creates a Database called 'testudo_bank'. teardownDB.py simply drops the 'testudo_bank', which will delete all tables and rows.

addCustomers.py is more complex. This script automates the process of randomly generating fake customers of the testudo_bank application and adding their data to the local MySQL DB. Randomly-generated elements include: Customer ID, First Name, Last Name, Bank Balance, and Password.

(These 3 scripts should be added to .gitignore in a future commit so that students can freely play around with the parameters and SQL queries in these scripts.)