### PR TITLE
centralize python script credentials

### DIFF
--- a/python-sql-scripts/addCustomers.py
+++ b/python-sql-scripts/addCustomers.py
@@ -2,12 +2,7 @@ import pymysql
 import names
 import random
 import string
-
-# Connection Config Values
-rds_endpoint='localhost'
-username='root'
-password='<Put MySQL Server Password Here>'
-database_name = 'testudo_bank'
+from credentials import rds_endpoint, username, password, database_name
 
 # SQL Config Values
 num_customers_to_add = 100

--- a/python-sql-scripts/createDB.py
+++ b/python-sql-scripts/createDB.py
@@ -2,12 +2,7 @@ import pymysql
 import names
 import random
 import string
-
-# Connection Config Values
-rds_endpoint='localhost'
-username='root'
-password='<Put MySQL Server Password Here>'
-database_name = 'testudo_bank'
+from credentials import rds_endpoint, username, password, database_name
 
 # Connect to local MySQL Server and create a DB called 'testudo_bank'
 connection = pymysql.connect(host=rds_endpoint, user=username, passwd = password)

--- a/python-sql-scripts/credentials.py
+++ b/python-sql-scripts/credentials.py
@@ -1,5 +1,5 @@
 # MySQL DB Connection Config Values
-rds_endpoint='localhost'
+mysql_endpoint='localhost'
 username='root'
 password='<Put MySQL Server Password Here>'
 database_name = 'testudo_bank'

--- a/python-sql-scripts/credentials.py
+++ b/python-sql-scripts/credentials.py
@@ -1,0 +1,5 @@
+# MySQL DB Connection Config Values
+rds_endpoint='localhost'
+username='root'
+password='<Put MySQL Server Password Here>'
+database_name = 'testudo_bank'

--- a/python-sql-scripts/teardownDB.py
+++ b/python-sql-scripts/teardownDB.py
@@ -2,12 +2,7 @@ import pymysql
 import names
 import random
 import string
-
-# Connection Config Values
-rds_endpoint='localhost'
-username='root'
-password='<Put MySQL Server Password Here>'
-database_name = 'testudo_bank'
+from credentials import rds_endpoint, username, password, database_name
 
 # Connect to local MySQL Server and delete a DB called 'testudo_bank'
 connection = pymysql.connect(host=rds_endpoint, user=username, passwd = password)


### PR DESCRIPTION
**Changes Made in this PR:**
- Moved all MySQL DB connection credential variables to a centralized location.
- In the future, new python scripts can just import the credentials from the centralized location instead of re-initializing them locally.
___
**`python-sql-scripts/credentials.py`**
- Stored all the MySQL DB connection credential variables here (endpoint, username, password, DB name).
___
**`python-sql-scripts/createDB.py` + `python-sql-scripts/addCustomers.py` + `python-sql-scripts/teardownDB.py`**
- Removed local MySQL DB connection credential variables, and import them from `credentials.py` instead.
