### PR TITLE
Fixed negative deposit/withdraw input bug

### DIFF
--- a/python-sql-scripts/addCustomers.py
+++ b/python-sql-scripts/addCustomers.py
@@ -6,7 +6,7 @@ import string
 # Connection Config Values
 rds_endpoint='localhost'
 username='root'
-password='<Put MySQL Server Password Here>'
+password='xxxxxxxxx'
 database_name = 'testudo_bank'
 
 # SQL Config Values

--- a/python-sql-scripts/createDB.py
+++ b/python-sql-scripts/createDB.py
@@ -6,7 +6,7 @@ import string
 # Connection Config Values
 rds_endpoint='localhost'
 username='root'
-password='<Put MySQL Server Password Here>'
+password='xxxxxxx'
 database_name = 'testudo_bank'
 
 # Connect to local MySQL Server and create a DB called 'testudo_bank'

--- a/python-sql-scripts/teardownDB.py
+++ b/python-sql-scripts/teardownDB.py
@@ -6,7 +6,7 @@ import string
 # Connection Config Values
 rds_endpoint='localhost'
 username='root'
-password='<Put MySQL Server Password Here>'
+password='xxxxx'
 database_name = 'testudo_bank'
 
 # Connect to local MySQL Server and delete a DB called 'testudo_bank'

--- a/src/main/java/net/codejava/MvcController.java
+++ b/src/main/java/net/codejava/MvcController.java
@@ -126,6 +126,12 @@ public class MvcController {
     String userPassword = jdbcTemplate.queryForObject(getUserPasswordSql, String.class);
 
     if (userPasswordAttempt.equals(userPassword)) {
+      
+      // Checks if user acidentally is trying to deposit a negative amount
+      if (user.getAmountToDeposit() < 0) {
+        return "welcome";
+      }
+
       // Execute SQL Update command that increments user's Balance by given amount from the deposit form.
       String balanceIncreaseSql = String.format("UPDATE Customers SET Balance = Balance + %d WHERE CustomerID='%s';", user.getAmountToDeposit(), userID);
       System.out.println(balanceIncreaseSql); // Print executed SQL update for debugging
@@ -193,6 +199,12 @@ public class MvcController {
     String userPassword = jdbcTemplate.queryForObject(getUserPasswordSql, String.class);
 
     if (userPasswordAttempt.equals(userPassword)) {
+
+      // Checks if user acidentally is trying to widthraw a negative amount
+      if (user.getAmountToWithdraw() < 0) {
+        return "welcome";
+      }
+
       // Execute SQL Update command that decrements Balance value for
       // user's row in Customers table using user.getAmountToWithdraw()
       String balanceIncreaseSql = String.format("UPDATE Customers SET Balance = Balance - %d WHERE CustomerID='%s';", user.getAmountToWithdraw(), userID);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,5 @@ spring.mvc.view.prefix=/WEB-INF/views/
 spring.mvc.view.suffix=.jsp
 spring.datasource.url=jdbc:mysql://localhost:3306/testudo_bank
 spring.datasource.username=root
-spring.datasource.password=<Your Local MySQL DB Password>
+spring.datasource.password=xxx
+spring.datasource.url=jdbc:mysql://localhost:3306/testudo_bank?serverTimezone=UTC


### PR DESCRIPTION
This pull request solves the issue of a user accidentally inputting a negative number when requesting to withdraw or deposit some money into their account. Before if the user accidentally requested a negative amount of money to withdraw, it would add to the account. Or if the user deposits a negative amount of money, it would remove that amount for their account. This fix instead re-directs the user back to the home page if their input is negative from now on, so the user doesn't have to deal with any confusion.  