### PR TITLE
add application.properties to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 !**/src/test/**/target/
 CODEOWNERS
 python-sql-scripts/
+src/main/resources/application.properties
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
Enables students to locally store their password and timezone configurations without fear of having that information included in commits.