### PR TITLE
use non-whole dollar amts in integ tests + some code cleanup

### DIFF
--- a/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
+++ b/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
@@ -17,6 +17,8 @@ import com.mysql.cj.jdbc.MysqlDataSource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
+
+import net.testudobank.MvcController;
 import net.testudobank.tests.MvcControllerIntegTest;
 
 public class MvcControllerIntegTestHelpers {
@@ -71,6 +73,11 @@ public class MvcControllerIntegTestHelpers {
   // Converts dollar amounts in frontend to penny representation in backend MySQL DB
   public static int convertDollarsToPennies(double dollarAmount) {
     return (int) (dollarAmount * 100);
+  }
+
+  // Applies overdraft interest rate to a dollar amount in pennies, and returns an int penny result
+  public static int applyOverdraftInterest(int dollarAmountInPennies) {
+    return (int) (dollarAmountInPennies * MvcController.INTEREST_RATE);
   }
 
   // Fetches current local time with no milliseconds because the MySQL DB has granularity only up to seconds (does not use milliseconds)

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -80,13 +80,13 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testSimpleDeposit() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $150. represented as pennies in the DB.
-    double CUSTOMER1_BALANCE = 150;
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-    // Prepare Deposit Form to Deposit $50 to customer 1's account.
-    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 50; // user input is in dollar amount, not pennies.
+    // Prepare Deposit Form to Deposit $12.34 to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
@@ -111,8 +111,8 @@ public class MvcControllerIntegTest {
     Map<String,Object> customer1Data = customersTableData.get(0);
     assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
 
-    // verify customer balance was increased by $50
-    double CUSTOMER1_EXPECTED_FINAL_BALANCE = 200;
+    // verify customer balance was increased by $12.34
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT;
     double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
     assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
 
@@ -139,13 +139,13 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testSimpleWithdraw() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $150. represented as pennies in the DB.
-    double CUSTOMER1_BALANCE = 150;
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-    // Prepare Withdraw Form to Withdraw $50 from customer 1's account.
-    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 50; // user input is in dollar amount, not pennies.
+    // Prepare Withdraw Form to Withdraw $12.34 from customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
@@ -170,8 +170,8 @@ public class MvcControllerIntegTest {
     Map<String,Object> customer1Data = customersTableData.get(0);
     assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
 
-    // verify customer balance was decreased by $50
-    double CUSTOMER1_EXPECTED_FINAL_BALANCE = 100;
+    // verify customer balance was decreased by $12.34
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE - CUSTOMER1_AMOUNT_TO_WITHDRAW;
     double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
     assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
 
@@ -199,13 +199,13 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testWithdrawTriggersOverdraft() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $100. represented as pennies in the DB.
-    double CUSTOMER1_BALANCE = 100;
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-    // Prepare Withdraw Form to Withdraw $110 from customer 1's account.
-    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 110; // user input is in dollar amount, not pennies.
+    // Prepare Withdraw Form to Withdraw $150 from customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 150; // user input is in dollar amount, not pennies.
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
@@ -231,7 +231,7 @@ public class MvcControllerIntegTest {
     int CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
     int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES = CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES - CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES;
-    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = (int)(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES * MvcController.INTEREST_RATE);
+    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers.applyOverdraftInterest(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES);
     System.out.println("Expected Overdraft Balance in pennies: " + CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES);
     assertEquals(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES, (int)customer1Data.get("OverdraftBalance"));
 
@@ -240,7 +240,7 @@ public class MvcControllerIntegTest {
     MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
   }
 
-/**
+  /**
    * The customer will be given an initial balance of $100 and will withdraw $1099.
    * This will test the scenario where the withdraw excess amount, which is $100 - $1099 = -$999,
    * results in a valid overdraft balance, but once the 2% interest rate is applied, will cross the limit
@@ -252,46 +252,43 @@ public class MvcControllerIntegTest {
    * @throws SQLException
    * @throws ScriptException
    */
-
   @Test
   public void testWithdrawOverdraftLimitExceeded() throws SQLException, ScriptException { 
+    //initialize customer1 with a balance of $100. this will be represented as pennies in DB.
+    double CUSTOMER1_BALANCE = 100;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-   //initialize customer1 with a balance of $100. this will be represented as pennies in DB.
-   double CUSTOMER1_BALANCE = 100;
-   int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-   MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
+    //Prepare Withdraw Form to withdraw $1099 from this customer's account.
+    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1099; 
+    User customer1WithdrawFormInputs = new User();
+    customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
+    customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW);
 
-   //Prepare Withdraw Form to withdraw $1099 from this customer's account.
-   double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1099; 
-   User customer1WithdrawFormInputs = new User();
-   customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
-   customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
-   customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    //Store the timestamp of the withdraw request to verify it in the TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    System.out.println("Timestamp when withdraw request sent: " + timeWhenWithdrawRequestSent);
 
-   //Store the timestamp of the withdraw request to verify it in the TransactionHistory table later
-   LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
-   System.out.println("Timestamp when withdraw request sent: " + timeWhenWithdrawRequestSent);
+    //Check the response when the withdraw request is submitted. This should return the user back to the home screen due to an invalid request
+    String responsePage = controller.submitWithdraw(customer1WithdrawFormInputs);
+    assertEquals("welcome", responsePage);
 
-   //Check the response when the withdraw request is submitted. This should return the user back to the home screen due to an invalid request
-   String responsePage = controller.submitWithdraw(customer1WithdrawFormInputs);
-   assertEquals("welcome", responsePage);
-   
-   //Fetch customer1's data from DB
-   List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    //Fetch customer1's data from DB
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
 
-   //Since the request did not go through, the balance is supposed to stay the same.
-   Map<String, Object> customer1Data = customersTableData.get(0);
-   assertEquals(CUSTOMER1_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    //Since the request did not go through, the balance is supposed to stay the same.
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
 
-   //Checks to make sure that the overdraft balance was not increased
-   assertEquals(0, (int)customer1Data.get("OverdraftBalance"));
+    //Checks to make sure that the overdraft balance was not increased
+    assertEquals(0, (int)customer1Data.get("OverdraftBalance"));
 
-   //check that TransactionHistory table is empty
-   List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-   assertTrue(transactionHistoryTableData.isEmpty());
+    //check that TransactionHistory table is empty
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+    assertTrue(transactionHistoryTableData.isEmpty());
 
   }
-
 
   /**
    * Verifies the case where a customer is in overdraft and deposits an amount
@@ -311,9 +308,9 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testDepositOverdraftClearedWithExcess() throws SQLException, ScriptException {
-    // initialize customer1 with an overdraft balance of $100. represented as pennies in the DB.
+    // initialize customer1 with an overdraft balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = 0;
-    double CUSTOMER1_OVERDRAFT_BALANCE = 100;
+    double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS);
@@ -374,9 +371,9 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testDepositOverdraftNotCleared() throws SQLException, ScriptException {
-    // initialize customer1 with an overdraft balance of $150. represented as pennies in the DB.
+    // initialize customer1 with an overdraft balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = 0;
-    double CUSTOMER1_OVERDRAFT_BALANCE = 150;
+    double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS);
@@ -440,13 +437,14 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testReversalOfSimpleDeposit() throws SQLException, ScriptException, InterruptedException {
-    // initialize customer1 with a balance of $150. represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     // No overdraft or numFraudReversals.
-    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(150);
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-    // Prepare Deposit Form to Deposit $50 to customer 1's account.
-    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 50; // user input is in dollar amount, not pennies.
+    // Prepare Deposit Form to Deposit $12.34 (to make sure this works for non-whole dollar amounts) to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
@@ -459,10 +457,11 @@ public class MvcControllerIntegTest {
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
-    // verify that customer1's balance is now $200 after the deposit
+    // verify customer1's balance after the deposit
     List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     Map<String,Object> customer1Data = customersTableData.get(0);
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(200);
+    double CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT = CUSTOMER1_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT; 
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT);
     assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES, (int)customer1Data.get("Balance"));
 
     // sleep for 1 second to ensure the timestamps of Deposit and Reversal are different (and sortable) in TransactionHistory table
@@ -483,8 +482,8 @@ public class MvcControllerIntegTest {
     customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     customer1Data = customersTableData.get(0);
 
-    // verify that customer1's balance is back to the original value of $150
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(150);
+    // verify that customer1's balance is back to the original value
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = CUSTOMER1_BALANCE_IN_PENNIES;
     assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
 
     // verify that customer1's numFraudReversals counter is now 1
@@ -525,13 +524,14 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testReversalOfSimpleWithdraw() throws SQLException, ScriptException, InterruptedException {
-    // initialize customer1 with a balance of $150. represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
     // No overdraft or numFraudReversals.
-    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(150);
+    double CUSTOMER1_BALANCE = 123.45;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES);
 
-    // Prepare Withdraw Form to Withdraw $50 to customer 1's account.
-    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 50; // user input is in dollar amount, not pennies.
+    // Prepare Withdraw Form to Withdraw $12.34 to customer 1's account.
+    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
@@ -544,10 +544,11 @@ public class MvcControllerIntegTest {
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
-    // verify that customer1's balance is now $100 after the withdraw
+    // verify customer1's balance after the withdraw
     List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     Map<String,Object> customer1Data = customersTableData.get(0);
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(100);
+    double CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW = CUSTOMER1_BALANCE - CUSTOMER1_AMOUNT_TO_WITHDRAW;
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW);
     assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES, (int)customer1Data.get("Balance"));
 
     // sleep for 1 second to ensure the timestamps of Deposit and Reversal are different (and sortable) in TransactionHistory table
@@ -568,8 +569,8 @@ public class MvcControllerIntegTest {
     customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     customer1Data = customersTableData.get(0);
 
-    // verify that customer1's balance is back to the original value of $150
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(150);
+    // verify that customer1's balance is back to the original value
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = CUSTOMER1_BALANCE_IN_PENNIES;
     assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
 
     // verify that customer1's numFraudReversals counter is now 1
@@ -581,11 +582,11 @@ public class MvcControllerIntegTest {
     Map<String,Object> customer1WithdrawTransactionLog = transactionHistoryTableData.get(0);
     Map<String,Object> customer1ReversalTransactionLog = transactionHistoryTableData.get(1);
 
-    // verify that the Deposit's details are accurately logged in the TransactionHistory table
+    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
     int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
     MvcControllerIntegTestHelpers.checkTransactionLog(customer1WithdrawTransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
 
-    // verify that the Reversal is accurately logged in the TransactionHistory table as a Withdraw
+    // verify that the Reversal is accurately logged in the TransactionHistory table as a Deposit
     int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES;
     MvcControllerIntegTestHelpers.checkTransactionLog(customer1ReversalTransactionLog, timeWhenReversalRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }


### PR DESCRIPTION
**Changes Made to Each File**

___
**'src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java'**
- Added a helper that applies the overdraft interest rate to a dollar amount in pennies, and gives the result in pennies.

___
**'src/test/java/net/testudobank/tests/MvcControllerIntegTest.java'**
- Replaced whole-dollar amounts in integ tests with dollar amounts like `$123.45` to ensure these features work for these trickier cases without having to write new tests.
- Configured tests so that the starting customer balance values can be changed to anything in the future and still work.
- Fixed up some existing errors in comments