### PR TITLE
specifiy surefire version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
       </plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Some students were having issues with Software Setup when leaving the version un-specified. @htariqusa 