### PR TITLE
Incorporated applyInterestToPennies

### DIFF
--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -183,6 +183,11 @@ public class MvcController {
     return dateTime;
   }
 
+  // Assignment 1: Applies Interest rate to given penny amount
+  private static int applyInterestRateToPennyAmount(int pennyAmount) {
+    return (int) (pennyAmount * INTEREST_RATE);
+  }
+
   // HTML POST HANDLERS ////
 
   /**
@@ -339,7 +344,7 @@ public class MvcController {
     int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
     if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = applyInterestRateToPennyAmount(excessWithdrawAmtInPennies);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
       // abort withdraw transaction if new overdraft balance exceeds max overdraft limit


### PR DESCRIPTION
This helper method abstracts away the explicit multiplication performed in newer overdraft interest calculation. This will affect the future development since any time the dev needs to apply the current interest rate to any amount of pennies; they can call this method instead of hard-coding the arithmetic needed.